### PR TITLE
f-string decorator in wrong place

### DIFF
--- a/correlator_pcaspy.py
+++ b/correlator_pcaspy.py
@@ -371,7 +371,7 @@ class LSiCorrelatorIOC(Driver):
 
             # Remove characters that are not allowed in filename and replace with underscore (_)
             compressed_experiment_name=remove_non_ascii(experiment_name)  #pylint: disable=unused-variable
-            filename = "f{run_number}_{compressed_experiment_name}_{timestamp}.dat"
+            filename = f"{run_number}_{compressed_experiment_name}_{timestamp}.dat"
 
         # Update last used filename PV
         full_filename = os.path.join(self.user_filepath, filename)


### PR DESCRIPTION
This caused file overwriting because the non-formatted string was coming back the same every time 😢 This is patched on NDXSANS2D and fixed the file overwriting so review just check c:\\temp\correlatortest\ to see the old file that did not have its name substituted as well as the new ones which were generated afterwards. 