### PR TITLE
HOTFIX - Fix Time Lags Data Output

### DIFF
--- a/correlator_driver_functions.py
+++ b/correlator_driver_functions.py
@@ -90,7 +90,7 @@ class LSiCorrelatorVendorInterface:
         time lag is greater than or equal to min_time_lag and Time lags that are greater
         than min_time_lag
         """
-        indices = [count for count in range(0, len(lags)) if lags[count] < min_time_lag]
+        indices = [count for count in range(0, len(lags)) if lags[count] >= min_time_lag]
 
         lags = np.delete(lags,indices)
         corr = np.delete(corr,indices)


### PR DESCRIPTION
Fix the removal of data with time lags lower than the minimum time lags set to output time lags data which was previously retuning an empty array.

Changes made have been tested on the LSiCorrelator and seem to now be outputting the correct data.
